### PR TITLE
Switch default model to deepseek-r1-0528

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ providing `--model-name` on the command line without `--llm-client`.
 
 ```yaml
 llm_client: openrouter-direct
-model_name: mistral-7b-instruct
+model_name: deepseek/deepseek-r1-0528:free
 ```
 
 The model name will determine the provider when `llm_client` is not

--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -1,2 +1,2 @@
 llm_client: openrouter-direct
-model_name: mistral-7b-instruct
+model_name: deepseek/deepseek-r1-0528:free

--- a/src/ii_agent/utils/constants.py
+++ b/src/ii_agent/utils/constants.py
@@ -1,6 +1,6 @@
 UPLOAD_FOLDER_NAME = "uploaded_files"
 COMPLETE_MESSAGE = "Completed the task."
-DEFAULT_MODEL = "claude-3-7-sonnet@20250219"
+DEFAULT_MODEL = "deepseek/deepseek-r1-0528:free"
 
 # Mapping of model names to the provider used to serve them. This is used
 # to automatically determine the correct LLM backend when only the model


### PR DESCRIPTION
## Summary
- default to the `deepseek/deepseek-r1-0528:free` model
- update example configuration in README

## Testing
- `ruff check src/ii_agent/utils/constants.py`
- `pytest -q`