### PR TITLE
Add OpenRouter LLM client

### DIFF
--- a/src/ii_agent/llm/__init__.py
+++ b/src/ii_agent/llm/__init__.py
@@ -2,6 +2,8 @@ from ii_agent.llm.base import LLMClient
 from ii_agent.llm.openai import OpenAIDirectClient
 from ii_agent.llm.anthropic import AnthropicDirectClient
 from ii_agent.llm.gemini import GeminiDirectClient
+from ii_agent.llm.openrouter import OpenRouterClient
+
 
 def get_client(client_name: str, **kwargs) -> LLMClient:
     """Get a client for a given client name."""
@@ -9,6 +11,8 @@ def get_client(client_name: str, **kwargs) -> LLMClient:
         return AnthropicDirectClient(**kwargs)
     elif client_name == "openai-direct":
         return OpenAIDirectClient(**kwargs)
+    elif client_name == "openrouter":
+        return OpenRouterClient(**kwargs)
     elif client_name == "gemini-direct":
         return GeminiDirectClient(**kwargs)
     else:
@@ -19,6 +23,7 @@ __all__ = [
     "LLMClient",
     "OpenAIDirectClient",
     "AnthropicDirectClient",
+    "OpenRouterClient",
     "GeminiDirectClient",
     "get_client",
 ]

--- a/src/ii_agent/llm/openrouter.py
+++ b/src/ii_agent/llm/openrouter.py
@@ -1,0 +1,27 @@
+import os
+import openai
+from ii_agent.llm.openai import OpenAIDirectClient
+
+
+class OpenRouterClient(OpenAIDirectClient):
+    """LLM client for OpenRouter (OpenAI-compatible API)."""
+
+    def __init__(self, model_name: str, max_retries: int = 2, cot_model: bool = True):
+        base_url = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+        api_key = os.getenv("OPENROUTER_API_KEY", "")
+        headers = {
+            "HTTP-Referer": os.getenv(
+                "OPENROUTER_HTTP_REFERER",
+                "https://github.com/IntelligentAgent/ii-agent",
+            ),
+            "X-Title": os.getenv("OPENROUTER_X_TITLE", "ii-agent"),
+        }
+        self.client = openai.OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            max_retries=max_retries,
+            default_headers=headers,
+        )
+        self.model_name = model_name
+        self.max_retries = max_retries
+        self.cot_model = cot_model


### PR DESCRIPTION
## Summary
- add `OpenRouterClient` with default headers and env var config
- expose OpenRouter client via llm package

## Testing
- `ruff check src/ii_agent/llm/openrouter.py src/ii_agent/llm/__init__.py --fix`
- `ruff format src/ii_agent/llm/openrouter.py src/ii_agent/llm/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6857540cc7588328b78291277699929f