### PR TITLE
Add OpenRouter client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ GEMINI_API_KEY=your_gemini_key
 # Option 3: For OpenAI models
 OPENAI_API_KEY=your_openai_key
 
+# Option 4: For OpenRouter models
+OPENROUTER_API_KEY=your_openrouter_key
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+
 # Search Provider API Key
 TAVILY_API_KEY=your_tavily_key
 
@@ -116,7 +120,16 @@ MEDIA_GCP_LOCATION=your_vertex_location
 
 Image Search Tool  (Optional, good for more beautiful output)
 ```
-SERPAPI_API_KEY=your_serpapi_key 
+SERPAPI_API_KEY=your_serpapi_key
+```
+
+### OpenRouter Model Names
+
+Prefix model identifiers with `openrouter/` or `or:` so the client factory can
+detect and use `OpenRouterClient`. Example:
+
+```bash
+--model-name openrouter/meta-llama/llama-3-70b-instruct
 ```
 
 

--- a/src/ii_agent/server/factories/client_factory.py
+++ b/src/ii_agent/server/factories/client_factory.py
@@ -28,7 +28,14 @@ class ClientFactory:
         Raises:
             ValueError: If the model name is not supported
         """
-        if "claude" in model_name:
+        if model_name.startswith("openrouter/") or model_name.startswith("or:"):
+            # Strip the prefix that signals OpenRouter usage
+            cleaned_name = model_name.split("/", 1)[1] if "/" in model_name else model_name.split(":", 1)[1]
+            return get_client(
+                "openrouter",
+                model_name=cleaned_name,
+            )
+        elif "claude" in model_name:
             return get_client(
                 "anthropic-direct",
                 model_name=model_name,


### PR DESCRIPTION
## Summary
- detect OpenRouter models in `ClientFactory`
- document OpenRouter environment variables and model naming

## Testing
- `pytest -q` *(fails: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6857589f65dc8328a388cf9445b0202d