### PR TITLE
Add OpenRouter direct client option

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -100,6 +100,8 @@ async def async_main():
     elif args.llm_client == "openai-direct":
         client_kwargs["azure_model"] = args.azure_model
         client_kwargs["cot_model"] = args.cot_model
+    elif args.llm_client == "openrouter-direct":
+        client_kwargs["cot_model"] = args.cot_model
 
     client = get_client(args.llm_client, **client_kwargs)
 

--- a/src/ii_agent/llm/__init__.py
+++ b/src/ii_agent/llm/__init__.py
@@ -11,7 +11,7 @@ def get_client(client_name: str, **kwargs) -> LLMClient:
         return AnthropicDirectClient(**kwargs)
     elif client_name == "openai-direct":
         return OpenAIDirectClient(**kwargs)
-    elif client_name == "openrouter":
+    elif client_name in ["openrouter", "openrouter-direct"]:
         return OpenRouterClient(**kwargs)
     elif client_name == "gemini-direct":
         return GeminiDirectClient(**kwargs)

--- a/src/ii_agent/server/app.py
+++ b/src/ii_agent/server/app.py
@@ -13,11 +13,12 @@ from ii_agent.core.config.utils import load_ii_agent_config
 logger = logging.getLogger(__name__)
 
 
-def create_app(args) -> FastAPI:
+def create_app(args, client_kwargs: dict | None = None) -> FastAPI:
     """Create and configure the FastAPI application.
 
     Args:
         args: Configuration arguments
+        client_kwargs: Optional keyword arguments for the LLM client
 
     Returns:
         FastAPI: Configured FastAPI application instance
@@ -36,6 +37,7 @@ def create_app(args) -> FastAPI:
 
     # Store global args in app state for access in endpoints
     app.state.workspace = args.workspace
+    app.state.client_kwargs = client_kwargs or {}
 
     # Create factory instances
     client_factory = ClientFactory(project_id=args.project_id, region=args.region)

--- a/utils.py
+++ b/utils.py
@@ -66,8 +66,11 @@ def parse_common_args(parser: ArgumentParser):
         "--llm-client",
         type=str,
         default="anthropic-direct",
-        choices=["anthropic-direct", "openai-direct"],
-        help="LLM client to use (anthropic-direct or openai-direct for LMStudio/local)",
+        choices=["anthropic-direct", "openai-direct", "openrouter-direct"],
+        help=(
+            "LLM client to use (anthropic-direct, openai-direct for LMStudio/local, "
+            "or openrouter-direct for OpenRouter)"
+        ),
     )
     parser.add_argument(
         "--model-name",

--- a/ws_server.py
+++ b/ws_server.py
@@ -29,8 +29,22 @@ def main():
     )
     args = parser.parse_args()
 
+    # Build client-specific kwargs for default settings
+    client_kwargs = {
+        "model_name": args.model_name,
+    }
+    if args.llm_client == "anthropic-direct":
+        client_kwargs["use_caching"] = False
+        client_kwargs["project_id"] = args.project_id
+        client_kwargs["region"] = args.region
+    elif args.llm_client == "openai-direct":
+        client_kwargs["azure_model"] = args.azure_model
+        client_kwargs["cot_model"] = args.cot_model
+    elif args.llm_client == "openrouter-direct":
+        client_kwargs["cot_model"] = args.cot_model
+
     # Create the FastAPI app
-    app = create_app(args)
+    app = create_app(args, client_kwargs)
 
     # Start the FastAPI server
     logger.info(f"Starting WebSocket server on {args.host}:{args.port}")


### PR DESCRIPTION
## Summary
- extend `--llm-client` options with `openrouter-direct`
- mention OpenRouter in CLI help text
- support `openrouter-direct` in `cli.py`
- pass client-specific kwargs through `ws_server.py`
- expose those kwargs via `create_app`
- allow `get_client` to accept `openrouter-direct`

## Testing
- `pytest -q` *(fails: ImportError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6857631900108328840ca8918c0bec27