### PR TITLE
Add OpenRouter env vars and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ TAVILY_API_KEY=your_tavily_key
 
 # GEMINI_API_KEY=put_your_gemini_key_here if you want to use gemini model
 # OPENAI_API_KEY=put_your_openai_key_here if you want to use openai models
+# OPENROUTER_API_KEY=put_your_openrouter_key_here
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+
 
 # For better performance you can use combine between SERPAPI and FIRECRAWL to replace TAVILY
 # SERPAPI = put your key here, also enable image search

--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ If you want to use vertex, set `GOOGLE_APPLICATION_CREDENTIALS` and run:
 GOOGLE_APPLICATION_CREDENTIALS=path-to-your-credential
 python cli.py --project-id YOUR_PROJECT_ID --region YOUR_REGION
 ```
+If you want to use OpenRouter, set `OPENROUTER_API_KEY` and optionally `OPENROUTER_BASE_URL` in `.env` and run:
+```bash
+python cli.py --llm-client openrouter-direct --model-name openrouter/meta-llama/llama-3-70b-instruct
+```
+
 
 Options:
 - `--project-id`: Google Cloud project ID
@@ -199,6 +204,11 @@ Options:
 When using Anthropic client:
 ```bash
 python ws_server.py --port 8000
+```
+
+When using OpenRouter:
+```bash
+python ws_server.py --port 8000 --llm-client openrouter-direct --model-name openrouter/meta-llama/llama-3-70b-instruct
 ```
 
 When using Vertex:

--- a/RUNNING_WITH_LOCAL_MODELS.md
+++ b/RUNNING_WITH_LOCAL_MODELS.md
@@ -65,6 +65,17 @@ python ws_server.py \
 
 Replace `<your-lmstudio-ip>:<port>` and `<your-model-identifier-in-lmstudio>` with the actual values from your LMStudio setup.
 
+## Using OpenRouter Models
+
+OpenRouter offers an OpenAI-compatible API for many community models. Set `OPENROUTER_API_KEY` and optionally `OPENROUTER_BASE_URL` before running. Start the agent with `--llm-client openrouter-direct` and prefix your model name with `openrouter/`.
+
+### Example
+```bash
+python cli.py 
+    --llm-client openrouter-direct 
+    --model-name openrouter/meta-llama/llama-3-70b-instruct
+```
+
 ## Troubleshooting
 
 *   **Connection Errors:**


### PR DESCRIPTION
## Summary
- document OpenRouter variables in `.env.example`
- explain how to run with OpenRouter in README and local models guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_685766558fec832883c048981c539cf0