### PR TITLE
Allow configuring LLM client via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ TAVILY_API_KEY=your_tavily_key
 # OPENROUTER_API_KEY=put_your_openrouter_key_here
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 
+# Optional configuration for model selection
+# LLM client to use (anthropic-direct, openai-direct, or openrouter-direct)
+LLM_CLIENT=anthropic-direct
+# Default model to use with the LLM client
+MODEL_NAME=claude-sonnet-4@20250514
+
 
 # For better performance you can use combine between SERPAPI and FIRECRAWL to replace TAVILY
 # SERPAPI = put your key here, also enable image search

--- a/docker/backend/run.sh
+++ b/docker/backend/run.sh
@@ -1,9 +1,18 @@
+LLM_CLIENT="${LLM_CLIENT:-anthropic-direct}"
+MODEL_NAME="${MODEL_NAME:-claude-sonnet-4@20250514}"
+
 if [ -n "$PROJECT_ID" ] && [ -n "$REGION" ]; then
   echo "Using Vertex Client"
   echo "PROJECT_ID: $PROJECT_ID"
   echo "REGION: $REGION"
-  exec xvfb-run --auto-servernum python ws_server.py --project-id $PROJECT_ID --region $REGION
+  exec xvfb-run --auto-servernum python ws_server.py \
+    --project-id "$PROJECT_ID" \
+    --region "$REGION" \
+    --llm-client "$LLM_CLIENT" \
+    --model-name "$MODEL_NAME"
 else
   echo "Using Anthropic Client, reading ANTHROPIC_API_KEY from .env"
-  exec xvfb-run --auto-servernum python ws_server.py
+  exec xvfb-run --auto-servernum python ws_server.py \
+    --llm-client "$LLM_CLIENT" \
+    --model-name "$MODEL_NAME"
 fi

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -26,6 +26,8 @@ services:
       - PROJECT_ID=${PROJECT_ID}
       - REGION=${REGION}
       - WORKSPACE_PATH=${WORKSPACE_PATH}
+      - LLM_CLIENT=${LLM_CLIENT:-anthropic-direct}
+      - MODEL_NAME=${MODEL_NAME:-claude-sonnet-4@20250514}
     volumes:
       - ${WORKSPACE_PATH:-../workspace}:/app/workspace
       #If file doesn't exist, use a dummy file


### PR DESCRIPTION
## Summary
- allow run.sh to pass through `LLM_CLIENT` and `MODEL_NAME`
- show `LLM_CLIENT` and `MODEL_NAME` vars in docker-compose
- document new variables in `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68576ff7cbcc8328ac50c264264df92b