### PR TITLE
Update docs for OpenRouter docker usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ TAVILY_API_KEY=your_tavily_key
 # OPENAI_API_KEY=put_your_openai_key_here if you want to use openai models
 # OPENROUTER_API_KEY=put_your_openrouter_key_here
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+# LLM_CLIENT=openrouter-direct
+# MODEL_NAME=openrouter/meta-llama/llama-3-70b-instruct
 
 
 # For better performance you can use combine between SERPAPI and FIRECRAWL to replace TAVILY

--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ PROJECT_ID=project-id \
 REGION=region \
 ./start.sh
 ```
+If you are using OpenRouter, run with these variables
+```
+LLM_CLIENT=openrouter-direct \
+MODEL_NAME=openrouter/meta-llama/llama-3-70b-instruct \
+OPENROUTER_API_KEY=your_openrouter_key \
+./start.sh
+```
 *Note: Due to a bug in the latest docker, if you receive and error, try running with `--force-recreate`. For example `./start.sh --force-recreate `*
 
 After running start.sh, you can check your application at: localhost:3000


### PR DESCRIPTION
## Summary
- add OpenRouter instructions for Docker usage
- list new env vars in `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6857745582bc8328b5011157af994365