### PR TITLE
Fix PYTHONPATH for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Add the repository's src directory to PYTHONPATH so local modules are importable
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if SRC_PATH.exists():
+    sys.path.insert(0, str(SRC_PATH))


### PR DESCRIPTION
## Summary
- add a test `conftest.py` that prepends `src` to PYTHONPATH

## Testing
- `pytest -q` *(fails: ImportError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68577958b35c832892cbdfa2e43e556e