### PR TITLE
Enable cross-platform shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Options:
 - `--workspace`: Path to the workspace directory (default: ./workspace)
 - `--needs-permission`: Require permission before executing commands
 - `--minimize-stdout-logs`: Reduce the amount of logs printed to stdout
+- `--shell-path`: Path to the shell executable used by the bash tool. Defaults
+  to `/bin/bash` on Unix systems and `powershell` on Windows.
 
 ### Web Interface
 

--- a/cli.py
+++ b/cli.py
@@ -129,6 +129,7 @@ async def async_main():
         message_queue=queue,
         container_id=args.docker_container_id,
         ask_user_permission=args.needs_permission,
+        shell_path=args.shell_path,
         tool_args={
             "deep_research": False,
             "pdf": True,

--- a/run_gaia.py
+++ b/run_gaia.py
@@ -276,7 +276,11 @@ async def answer_single_question(
         StrReplaceEditorTool(
             workspace_manager=workspace_manager, message_queue=message_queue
         ),
-        BashTool(workspace_root=workspace_path, require_confirmation=False),
+        BashTool(
+            workspace_root=workspace_path,
+            require_confirmation=False,
+            shell_path=args.shell_path,
+        ),
         BrowserNavigationTool(browser=browser),
         BrowserRestartTool(browser=browser),
         BrowserScrollDownTool(browser=browser),

--- a/src/ii_agent/server/app.py
+++ b/src/ii_agent/server/app.py
@@ -47,6 +47,7 @@ def create_app(args, client_kwargs: dict | None = None) -> FastAPI:
         minimize_stdout_logs=args.minimize_stdout_logs,
         docker_container_id=args.docker_container_id,
         needs_permission=args.needs_permission,
+        shell_path=args.shell_path,
     )
     agent_factory = AgentFactory(agent_config)
 

--- a/src/ii_agent/server/factories/agent_factory.py
+++ b/src/ii_agent/server/factories/agent_factory.py
@@ -33,6 +33,7 @@ class AgentConfig:
         minimize_stdout_logs: bool = False,
         docker_container_id: str = None,
         needs_permission: bool = True,
+        shell_path: str | None = None,
         max_output_tokens_per_turn: int = MAX_OUTPUT_TOKENS_PER_TURN,
         max_turns: int = MAX_TURNS,
         token_budget: int = TOKEN_BUDGET,
@@ -41,6 +42,7 @@ class AgentConfig:
         self.minimize_stdout_logs = minimize_stdout_logs
         self.docker_container_id = docker_container_id
         self.needs_permission = needs_permission
+        self.shell_path = shell_path
         self.max_output_tokens_per_turn = max_output_tokens_per_turn
         self.max_turns = max_turns
         self.token_budget = token_budget
@@ -176,6 +178,7 @@ class AgentFactory:
             container_id=self.config.docker_container_id,
             ask_user_permission=self.config.needs_permission,
             tool_args=tool_args,
+            shell_path=self.config.shell_path,
         )
 
         # Choose system prompt based on tool args

--- a/src/ii_agent/tools/tool_manager.py
+++ b/src/ii_agent/tools/tool_manager.py
@@ -63,6 +63,7 @@ def get_system_tools(
     container_id: Optional[str] = None,
     ask_user_permission: bool = False,
     tool_args: Dict[str, Any] = None,
+    shell_path: Optional[str] = None,
 ) -> list[LLMTool]:
     """
     Retrieves a list of all system tools.
@@ -72,11 +73,15 @@ def get_system_tools(
     """
     if container_id is not None:
         bash_tool = create_docker_bash_tool(
-            container=container_id, ask_user_permission=ask_user_permission
+            container=container_id,
+            ask_user_permission=ask_user_permission,
+            shell_path=shell_path,
         )
     else:
         bash_tool = create_bash_tool(
-            ask_user_permission=ask_user_permission, cwd=workspace_manager.root
+            ask_user_permission=ask_user_permission,
+            cwd=workspace_manager.root,
+            shell_path=shell_path,
         )
 
     logger = logging.getLogger("presentation_context_manager")

--- a/utils.py
+++ b/utils.py
@@ -38,6 +38,14 @@ def parse_common_args(parser: ArgumentParser):
         help="(Optional) Docker container ID to run commands in.",
     )
     parser.add_argument(
+        "--shell-path",
+        type=str,
+        default=None,
+        help=(
+            "Path to shell executable (defaults to powershell on Windows or /bin/bash on Unix)"
+        ),
+    )
+    parser.add_argument(
         "--minimize-stdout-logs",
         help="Minimize the amount of logs printed to stdout.",
         action="store_true",


### PR DESCRIPTION
## Summary
- allow `start_persistent_shell` to use a configurable shell
- pass shell path through Bash tool helpers
- expose `--shell-path` CLI option and propagate to server and GAIA runner
- document shell configuration in README
- update tests for new parameter

## Testing
- `pytest -q` *(fails: ImportError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68586595649083288f7550b17caebe88