### PR TITLE
Improve tool logging and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Options:
 - `--minimize-stdout-logs`: Reduce the amount of logs printed to stdout
 - `--shell-path`: Path to the shell executable used by the bash tool. Defaults
   to `/bin/bash` on Unix systems and `powershell` on Windows.
+- All tool activity is logged to `tool_calls.log` in the working directory for
+  troubleshooting.
 
 ### Web Interface
 

--- a/src/ii_agent/llm/openai.py
+++ b/src/ii_agent/llm/openai.py
@@ -216,6 +216,12 @@ class OpenAIDirectClient(LLMClient):
                     extra_body["max_completion_tokens"] = max_tokens
                     openai_max_tokens = OpenAI_NOT_GIVEN
                     openai_temperature = OpenAI_NOT_GIVEN
+                logger.debug(
+                    "Calling model %s with tool_choice=%s tools=%s",
+                    self.model_name,
+                    tool_choice_param,
+                    [t.name for t in tools],
+                )
                 response = self.client.chat.completions.create(
                     model=self.model_name,
                     messages=openai_messages,

--- a/src/ii_agent/server/factories/client_factory.py
+++ b/src/ii_agent/server/factories/client_factory.py
@@ -1,5 +1,8 @@
 from ii_agent.llm.base import LLMClient
 from ii_agent.llm import get_client
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class ClientFactory:
@@ -15,11 +18,14 @@ class ClientFactory:
         self.project_id = project_id
         self.region = region
 
-    def create_client(self, model_name: str, **kwargs) -> LLMClient:
+    def create_client(
+        self, model_name: str, tool_args: dict | None = None, **kwargs
+    ) -> LLMClient:
         """Create an LLM client based on the model name and configuration.
 
         Args:
             model_name: The name of the model to use
+            tool_args: Optional dict of tool settings used for logging
             **kwargs: Additional configuration options like thinking_tokens
 
         Returns:
@@ -31,6 +37,13 @@ class ClientFactory:
             cleaned_name = model_name[len("openrouter/") :]
         elif model_name.startswith("or:"):
             cleaned_name = model_name[len("or:") :]
+
+        enabled_tools = [k for k, v in (tool_args or {}).items() if v]
+        logger.info(
+            "Using model %s with tools %s",
+            cleaned_name,
+            ", ".join(enabled_tools) if enabled_tools else "none",
+        )
 
         try:
             return get_client(

--- a/src/ii_agent/server/websocket/chat_session.py
+++ b/src/ii_agent/server/websocket/chat_session.py
@@ -140,7 +140,9 @@ class ChatSession:
 
             # Create LLM client using factory
             client = self.client_factory.create_client(
-                init_content.model_name, thinking_tokens=init_content.thinking_tokens
+                init_content.model_name,
+                tool_args=init_content.tool_args,
+                thinking_tokens=init_content.thinking_tokens,
             )
 
             # Create agent using factory
@@ -344,7 +346,9 @@ class ChatSession:
             enhance_content = EnhancePromptContent(**content)
 
             # Create LLM client using factory
-            client = self.client_factory.create_client(enhance_content.model_name)
+            client = self.client_factory.create_client(
+                enhance_content.model_name, tool_args=None
+            )
 
             # Call the enhance_prompt function
             success, message, enhanced_prompt = await enhance_user_prompt(

--- a/src/ii_agent/tools/tool_manager.py
+++ b/src/ii_agent/tools/tool_manager.py
@@ -234,7 +234,16 @@ class AgentToolManager:
         tool_input = tool_params.tool_input
         self.logger_for_agent_logs.info(f"Running tool: {tool_name}")
         self.logger_for_agent_logs.info(f"Tool input: {tool_input}")
-        result = await llm_tool.run_async(tool_input, history)
+        try:
+            result = await llm_tool.run_async(tool_input, history)
+        except Exception as exc:
+            self.logger_for_agent_logs.error(
+                "Error running tool %s with input %s: %s",
+                tool_name,
+                tool_input,
+                exc,
+            )
+            raise
 
         tool_input_str = "\n".join([f" - {k}: {v}" for k, v in tool_input.items()])
 


### PR DESCRIPTION
## Summary
- log model selection and enabled tools in `ClientFactory`
- add debug log before OpenAI completion
- record tool errors in `AgentToolManager`
- pass tool arguments when creating clients
- document `tool_calls.log`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'anthropic')*

------
https://chatgpt.com/codex/tasks/task_e_685b6c525fc88328bdffff6d0c5fd860