### PR TITLE
Add model tool defaults mapping

### DIFF
--- a/src/ii_agent/core/config/model_tool_map.py
+++ b/src/ii_agent/core/config/model_tool_map.py
@@ -1,0 +1,22 @@
+from typing import Dict, Any
+
+# Mapping of model names to their default tool settings. Incoming
+# tool flags from the UI will override these defaults.
+MODEL_TOOL_DEFAULTS: Dict[str, Dict[str, Any]] = {
+    "anthropic/claude-sonnet-4": {
+        "deep_research": False,
+        "pdf": True,
+        "media_generation": True,
+        "audio_generation": True,
+        "browser": True,
+    },
+    "anthropic/claude-opus-4": {
+        "deep_research": False,
+        "pdf": True,
+        "media_generation": True,
+        "audio_generation": True,
+        "browser": True,
+    },
+}
+
+__all__ = ["MODEL_TOOL_DEFAULTS"]

--- a/src/ii_agent/server/factories/client_factory.py
+++ b/src/ii_agent/server/factories/client_factory.py
@@ -1,5 +1,6 @@
 from ii_agent.llm.base import LLMClient
 from ii_agent.llm import get_client
+from ii_agent.core.config.model_tool_map import MODEL_TOOL_DEFAULTS
 import logging
 
 logger = logging.getLogger(__name__)
@@ -38,7 +39,12 @@ class ClientFactory:
         elif model_name.startswith("or:"):
             cleaned_name = model_name[len("or:") :]
 
-        enabled_tools = [k for k, v in (tool_args or {}).items() if v]
+        merged_tool_args = {
+            **MODEL_TOOL_DEFAULTS.get(model_name, {}),
+            **(tool_args or {}),
+        }
+
+        enabled_tools = [k for k, v in merged_tool_args.items() if v]
         logger.info(
             "Using model %s with tools %s",
             cleaned_name,

--- a/src/ii_agent/server/websocket/chat_session.py
+++ b/src/ii_agent/server/websocket/chat_session.py
@@ -20,6 +20,7 @@ from ii_agent.server.models.messages import (
     EditQueryContent,
 )
 from ii_agent.server.factories import ClientFactory, AgentFactory
+from ii_agent.core.config.model_tool_map import MODEL_TOOL_DEFAULTS
 
 logger = logging.getLogger(__name__)
 
@@ -138,10 +139,15 @@ class ChatSession:
         try:
             init_content = InitAgentContent(**content)
 
+            model_defaults = MODEL_TOOL_DEFAULTS.get(
+                init_content.model_name, {}
+            )
+            merged_tool_args = {**model_defaults, **init_content.tool_args}
+
             # Create LLM client using factory
             client = self.client_factory.create_client(
                 init_content.model_name,
-                tool_args=init_content.tool_args,
+                tool_args=merged_tool_args,
                 thinking_tokens=init_content.thinking_tokens,
             )
 
@@ -151,7 +157,7 @@ class ChatSession:
                 self.session_uuid,
                 self.workspace_manager,
                 self.websocket,
-                init_content.tool_args,
+                merged_tool_args,
                 self.file_store,
             )
 


### PR DESCRIPTION
## Summary
- add model_tool_map config providing default tool flags per model
- log merged tool flags in ClientFactory
- merge default tool flags with UI flags when initializing the agent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'anthropic')*

------
https://chatgpt.com/codex/tasks/task_e_685c17e801588328b009df741e351c1f