### PR TITLE
Add model iteration test for deep research tool

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,61 @@ from pathlib import Path
 SRC_PATH = Path(__file__).resolve().parents[1] / "src"
 if SRC_PATH.exists():
     sys.path.insert(0, str(SRC_PATH))
+
+# Provide a minimal "anthropic" stub so tests can run without the package
+if "anthropic" not in sys.modules:
+    import types
+
+    anthropic_stub = types.ModuleType("anthropic")
+    anthropic_stub.NOT_GIVEN = None
+    anthropic_stub.APIConnectionError = Exception
+    anthropic_stub.InternalServerError = Exception
+    anthropic_stub.RateLimitError = Exception
+    anthropic_stub.Anthropic = object
+    anthropic_stub.AnthropicVertex = object
+
+    exceptions_stub = types.ModuleType("anthropic._exceptions")
+    exceptions_stub.OverloadedError = Exception
+
+    types_stub = types.ModuleType("anthropic.types")
+    types_stub.TextBlock = object
+    types_stub.ThinkingBlock = object
+    types_stub.RedactedThinkingBlock = object
+    types_stub.ImageBlockParam = object
+    types_stub.ToolParam = object
+    types_stub.ToolResultBlockParam = object
+    types_stub.ToolUseBlock = object
+
+    message_params_stub = types.ModuleType(
+        "anthropic.types.message_create_params"
+    )
+    message_params_stub.ToolChoiceToolChoiceAny = object
+    message_params_stub.ToolChoiceToolChoiceAuto = object
+    message_params_stub.ToolChoiceToolChoiceTool = object
+
+    sys.modules["anthropic"] = anthropic_stub
+    sys.modules["anthropic._exceptions"] = exceptions_stub
+    sys.modules["anthropic.types"] = types_stub
+    sys.modules["anthropic.types.message_create_params"] = message_params_stub
+
+# Provide a minimal "google.genai" stub for Gemini client imports
+if "google" not in sys.modules:
+    import types
+    google_stub = types.ModuleType("google")
+    genai_stub = types.ModuleType("google.genai")
+    genai_stub.types = types.ModuleType("google.genai.types")
+    genai_stub.errors = types.ModuleType("google.genai.errors")
+    google_stub.genai = genai_stub
+    sys.modules["google"] = google_stub
+    sys.modules["google.genai"] = genai_stub
+    sys.modules["google.genai.types"] = genai_stub.types
+    sys.modules["google.genai.errors"] = genai_stub.errors
+
+# Ensure llm.base exports ThinkingBlock aliases even if anthropic is stubbed
+import ii_agent.llm.base as llm_base
+if not hasattr(llm_base, "ThinkingBlock"):
+    llm_base.ThinkingBlock = getattr(llm_base, "AnthropicThinkingBlock", object)
+if not hasattr(llm_base, "RedactedThinkingBlock"):
+    llm_base.RedactedThinkingBlock = getattr(
+        llm_base, "AnthropicRedactedThinkingBlock", object
+    )

--- a/tests/pytest_asyncio.py
+++ b/tests/pytest_asyncio.py
@@ -1,0 +1,21 @@
+import asyncio
+import pytest
+import inspect
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "asyncio: mark test as asynchronous")
+
+
+def pytest_pyfunc_call(pyfuncitem):
+    if 'asyncio' in pyfuncitem.keywords:
+        func = pyfuncitem.obj
+        if inspect.iscoroutinefunction(func):
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                loop.run_until_complete(func(**pyfuncitem.funcargs))
+            finally:
+                loop.close()
+            return True
+    return None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,26 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from ii_agent.core.config.model_tool_map import MODEL_TOOL_DEFAULTS
+from ii_agent.tools import get_system_tools
+from ii_agent.utils import WorkspaceManager
+
+
+@pytest.mark.parametrize("model_name", list(MODEL_TOOL_DEFAULTS.keys()))
+def test_deep_research_tool_present(tmp_path, model_name):
+    client = MagicMock()
+    client.model_name = model_name
+
+    workspace_manager = WorkspaceManager(tmp_path)
+    tools = get_system_tools(
+        client=client,
+        workspace_manager=workspace_manager,
+        message_queue=asyncio.Queue(),
+        container_id=None,
+        ask_user_permission=False,
+        tool_args={"deep_research": True},
+    )
+    tool_names = [tool.name for tool in tools]
+    assert "deep_research" in tool_names


### PR DESCRIPTION
## Summary
- stub missing dependencies in tests via `tests/conftest.py`
- add a simple pytest plugin for async tests
- create `tests/test_tools.py` to ensure every model exposes `deep_research`

## Testing
- `pytest tests/test_tools.py -q`
- `pytest -q` *(fails: ModuleNotFoundError/AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_685c287959a4832882d942c2161284e7