### PR TITLE
Add Firecrawl search and multi-engine mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,8 @@ MODEL_NAME=claude-sonnet-4@20250514
 
 
 # For better performance you can use combine between SERPAPI and FIRECRAWL to replace TAVILY
-# SERPAPI = put your key here, also enable image search
-# FIRE_CRAWL = put_your_fire_crawl_key, enable better crawler
+# SERPAPI_API_KEY=put_your_serpapi_key
+# FIRECRAWL_KEY=put_your_firecrawl_key
 
 # We are supporting video generation and image generation via Vertex, if you want to use make sure you set following enviroment
 # MEDIA_GCS_OUTPUT_BUCKET=gs://your_bucket_here

--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ STATIC_FILE_BASE_URL=http://localhost:8000/
 We also support other search and crawl provider such as FireCrawl and SerpAPI (Optional but yield better performance):
 ```bash
 JINA_API_KEY=your_jina_key
-FIRECRAWL_API_KEY=your_firecrawl_key
-SERPAPI_API_KEY=your_serpapi_key 
+FIRECRAWL_KEY=your_firecrawl_key  # FIRECRAWL_API_KEY also supported
+SERPAPI_API_KEY=your_serpapi_key
 ```
+Set ``multi_engine=True`` when creating ``WebSearchTool`` to combine results from
+all available engines.
 
 We are supporting image generation and video generation tool by Vertex AI (Optional, good for more creative output), to use this, you need to set up the following variables:
 ```bash

--- a/src/ii_agent/tools/web_search_tool.py
+++ b/src/ii_agent/tools/web_search_tool.py
@@ -19,9 +19,11 @@ class WebSearchTool(LLMTool):
     }
     output_type = "string"
 
-    def __init__(self, max_results=5, **kwargs):
+    def __init__(self, max_results: int = 5, multi_engine: bool = False, **kwargs):
         self.max_results = max_results
-        self.web_search_client = create_search_client(max_results=max_results, **kwargs)
+        self.web_search_client = create_search_client(
+            max_results=max_results, multi_engine=multi_engine, **kwargs
+        )
 
     async def run_impl(
         self,


### PR DESCRIPTION
## Summary
- support Firecrawl in `web_search_client`
- create optional multi-engine search mode
- allow `WebSearchTool` to enable multi-engine combination
- document new `FIRECRAWL_KEY` variable and update env example

## Testing
- `ruff format src/ii_agent/tools/web_search_client.py src/ii_agent/tools/web_search_tool.py`
- `ruff check src/ii_agent/tools/web_search_client.py src/ii_agent/tools/web_search_tool.py`
- `pytest -q` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c3037484c832892c50c3b7f419e8d