### PR TITLE
Add deep research default test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,8 @@ if "anthropic" not in sys.modules:
 
     types_stub = types.ModuleType("anthropic.types")
     types_stub.TextBlock = object
-    types_stub.ThinkingBlock = object
-    types_stub.RedactedThinkingBlock = object
+    types_stub.ThinkingBlock = type("ThinkingBlock", (), {})
+    types_stub.RedactedThinkingBlock = type("RedactedThinkingBlock", (), {})
     types_stub.ImageBlockParam = object
     types_stub.ToolParam = object
     types_stub.ToolResultBlockParam = object

--- a/tests/pytest_asyncio.py
+++ b/tests/pytest_asyncio.py
@@ -14,7 +14,11 @@ def pytest_pyfunc_call(pyfuncitem):
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             try:
-                loop.run_until_complete(func(**pyfuncitem.funcargs))
+                kwargs = {
+                    name: pyfuncitem.funcargs[name]
+                    for name in pyfuncitem._fixtureinfo.argnames
+                }
+                loop.run_until_complete(func(**kwargs))
             finally:
                 loop.close()
             return True

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -24,3 +24,27 @@ def test_deep_research_tool_present(tmp_path, model_name):
     )
     tool_names = [tool.name for tool in tools]
     assert "deep_research" in tool_names
+
+
+# Models that have deep_research enabled by default
+models_with_deep_research = [
+    name for name, defaults in MODEL_TOOL_DEFAULTS.items() if defaults.get("deep_research")
+]
+
+
+@pytest.mark.parametrize("model_name", models_with_deep_research)
+def test_deep_research_default_enabled(tmp_path, model_name):
+    client = MagicMock()
+    client.model_name = model_name
+
+    workspace_manager = WorkspaceManager(tmp_path)
+    tools = get_system_tools(
+        client=client,
+        workspace_manager=workspace_manager,
+        message_queue=asyncio.Queue(),
+        container_id=None,
+        ask_user_permission=False,
+        tool_args={},
+    )
+    tool_names = [tool.name for tool in tools]
+    assert "deep_research" in tool_names


### PR DESCRIPTION
## Summary
- add parameterized test for models with deep research enabled by default
- fix pytest_asyncio plugin to pass only requested fixtures
- adjust anthropic stub so ThinkingBlock checks behave correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5c2b39948328adb888b97af62523