### PR TITLE
Update OpenRouter tool forcing logic

### DIFF
--- a/tests/test_openrouter_client.py
+++ b/tests/test_openrouter_client.py
@@ -32,3 +32,42 @@ def test_deep_research_triggers_tool_choice(monkeypatch):
     kwargs = mock_api.chat.completions.create.call_args.kwargs
     assert kwargs["tool_choice"] == "required"
     assert kwargs["extra_body"]["parallel_tool_calls"] is False
+
+
+def test_force_tool_flag_respected(monkeypatch):
+    client = OpenRouterClient(model_name="test")
+    monkeypatch.setattr(
+        OpenRouterClient, "DEEP_RESEARCH_TOKEN_THRESHOLD", 10, raising=False
+    )
+    mock_api = MagicMock()
+    mock_api.chat.completions.create.return_value = make_response()
+    client.client = mock_api
+
+    messages = [[TextPrompt(text="a" * 40)]]
+
+    client.generate(
+        messages=messages,
+        max_tokens=5,
+        tool_args={"deep_research": True, "force_tool": False},
+    )
+
+    kwargs = mock_api.chat.completions.create.call_args.kwargs
+    assert kwargs["tool_choice"] != "required"
+
+
+def test_flash_model_forces_tool_choice(monkeypatch):
+    client = OpenRouterClient(model_name="super-flash-model")
+    mock_api = MagicMock()
+    mock_api.chat.completions.create.return_value = make_response()
+    client.client = mock_api
+
+    messages = [[TextPrompt(text="hi")]]
+
+    client.generate(
+        messages=messages,
+        max_tokens=5,
+    )
+
+    kwargs = mock_api.chat.completions.create.call_args.kwargs
+    assert kwargs["tool_choice"] == "required"
+    assert kwargs["extra_body"]["parallel_tool_calls"] is False


### PR DESCRIPTION
## Summary
- lower `DEEP_RESEARCH_TOKEN_THRESHOLD` to 75 tokens
- respect `force_tool` flag in OpenRouter client
- force tool use on `flash` or `nano` models or when `force_tool` is true
- add debug logging for overridden tool choice
- expand OpenRouter client tests to cover `force_tool` logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c60c42bd88328b637e7485a18a415