### PR TITLE
Add force_tool toggle

### DIFF
--- a/frontend/components/settings-drawer.tsx
+++ b/frontend/components/settings-drawer.tsx
@@ -47,7 +47,6 @@ const SettingsDrawer = ({ isOpen, onClose }: SettingsDrawerProps) => {
     dispatch({
       type: "SET_TOOL_SETTINGS",
       payload: {
-        ...state.toolSettings,
         [tool]: !state.toolSettings[tool],
       },
     });
@@ -62,6 +61,7 @@ const SettingsDrawer = ({ isOpen, onClose }: SettingsDrawerProps) => {
         media_generation: true,
         audio_generation: true,
         browser: true,
+        force_tool: true,
         thinking_tokens: 10000,
       },
     });
@@ -73,7 +73,6 @@ const SettingsDrawer = ({ isOpen, onClose }: SettingsDrawerProps) => {
     dispatch({
       type: "SET_TOOL_SETTINGS",
       payload: {
-        ...state.toolSettings,
         thinking_tokens: effort === "high" ? 10000 : 0,
       },
     });
@@ -92,7 +91,7 @@ const SettingsDrawer = ({ isOpen, onClose }: SettingsDrawerProps) => {
       if (!isClaudeModel && state.toolSettings.thinking_tokens > 0) {
         dispatch({
           type: "SET_TOOL_SETTINGS",
-          payload: { ...state.toolSettings, thinking_tokens: 0 },
+          payload: { thinking_tokens: 0 },
         });
       }
     }
@@ -332,6 +331,22 @@ const SettingsDrawer = ({ isOpen, onClose }: SettingsDrawerProps) => {
                       id="browser"
                       checked={state.toolSettings.browser}
                       onCheckedChange={() => handleToolToggle("browser")}
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-1">
+                      <Label htmlFor="force-tool" className="text-gray-300">
+                        Force tools on long queries
+                      </Label>
+                      <p className="text-xs text-gray-400">
+                        Require tool use when prompts are lengthy
+                      </p>
+                    </div>
+                    <Switch
+                      id="force-tool"
+                      checked={state.toolSettings.force_tool}
+                      onCheckedChange={() => handleToolToggle("force_tool")}
                     />
                   </div>
                 </div>

--- a/frontend/context/app-context.tsx
+++ b/frontend/context/app-context.tsx
@@ -56,7 +56,10 @@ export type AppAction =
   | { type: "SET_BROWSER_URL"; payload: string }
   | { type: "SET_GENERATING_PROMPT"; payload: boolean }
   | { type: "SET_EDITING_MESSAGE"; payload: Message | undefined }
-  | { type: "SET_TOOL_SETTINGS"; payload: AppState["toolSettings"] }
+  | {
+      type: "SET_TOOL_SETTINGS";
+      payload: Partial<AppState["toolSettings"]>;
+    }
   | { type: "SET_SELECTED_MODEL"; payload: string | undefined }
   | { type: "SET_WS_CONNECTION_STATE"; payload: WebSocketConnectionState }
   | { type: "SET_AGENT_INITIALIZED"; payload: boolean }
@@ -91,6 +94,7 @@ const initialState: AppState = {
     media_generation: true,
     audio_generation: true,
     browser: true,
+    force_tool: true,
     thinking_tokens: 10000,
   },
   wsConnectionState: WebSocketConnectionState.CONNECTING,
@@ -164,7 +168,10 @@ function appReducer(state: AppState, action: AppAction): AppState {
     case "SET_EDITING_MESSAGE":
       return { ...state, editingMessage: action.payload };
     case "SET_TOOL_SETTINGS":
-      return { ...state, toolSettings: action.payload };
+      return {
+        ...state,
+        toolSettings: { ...state.toolSettings, ...action.payload },
+      };
     case "SET_SELECTED_MODEL":
       return { ...state, selectedModel: action.payload };
     case "SET_WS_CONNECTION_STATE":

--- a/frontend/typings/agent.ts
+++ b/frontend/typings/agent.ts
@@ -166,6 +166,7 @@ export interface ToolSettings {
   media_generation: boolean;
   audio_generation: boolean;
   browser: boolean;
+  force_tool: boolean;
   thinking_tokens: number;
 }
 export interface GooglePickerResponse {


### PR DESCRIPTION
## Summary
- add `force_tool` to `ToolSettings`
- persist the new flag in app context
- merge tool settings updates
- allow toggling `force_tool` from the settings drawer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c648130bc8328a9e2f2421a0b4a72