### PR TITLE
Apply default model tool settings on change

### DIFF
--- a/frontend/components/settings-drawer.tsx
+++ b/frontend/components/settings-drawer.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from "./ui/input";
 import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
 import { AVAILABLE_MODELS, ToolSettings } from "@/typings/agent";
+import { MODEL_TOOL_DEFAULTS } from "@/config/model-tool-defaults";
 import { useAppContext } from "@/context/app-context";
 
 interface SettingsDrawerProps {
@@ -77,6 +78,14 @@ const SettingsDrawer = ({ isOpen, onClose }: SettingsDrawerProps) => {
       },
     });
   };
+
+  useEffect(() => {
+    const defaults = MODEL_TOOL_DEFAULTS[state.selectedModel] || {};
+    const merged = { ...state.toolSettings, ...defaults };
+    if (JSON.stringify(merged) !== JSON.stringify(state.toolSettings)) {
+      dispatch({ type: "SET_TOOL_SETTINGS", payload: merged });
+    }
+  }, [state.selectedModel]);
 
   useEffect(() => {
     if (state.selectedModel) {

--- a/frontend/config/model-tool-defaults.ts
+++ b/frontend/config/model-tool-defaults.ts
@@ -1,0 +1,28 @@
+export const MODEL_TOOL_DEFAULTS: Record<string, Partial<import("@/typings/agent").ToolSettings>> = {
+  "anthropic/claude-sonnet-4": {
+    deep_research: false,
+    pdf: true,
+    media_generation: true,
+    audio_generation: true,
+    browser: true,
+  },
+  "anthropic/claude-opus-4": {
+    deep_research: false,
+    pdf: true,
+    media_generation: true,
+    audio_generation: true,
+    browser: true,
+  },
+  "openrouter/google/gemini-2.5-flash-001": {
+    deep_research: true,
+  },
+  "openrouter/google/gemini-2.5-pro": {
+    deep_research: true,
+  },
+  "openrouter/openai/gpt-4.1-mini": {
+    deep_research: true,
+  },
+  "openrouter/openai/gpt-4.1-nano": {
+    deep_research: true,
+  },
+};


### PR DESCRIPTION
## Summary
- sync model-specific tool defaults between frontend and backend
- automatically merge defaults when changing the selected model

## Testing
- `npm run lint` within `frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6b903e5883288168377aeec0e385