### PR TITLE
Implement progress updates for DeepResearchTool

### DIFF
--- a/src/ii_agent/tools/tool_manager.py
+++ b/src/ii_agent/tools/tool_manager.py
@@ -134,7 +134,7 @@ def get_system_tools(
         if tool_args.get("sequential_thinking", False):
             tools.append(SequentialThinkingTool())
         if tool_args.get("deep_research", False):
-            tools.append(DeepResearchTool())
+            tools.append(DeepResearchTool(message_queue=message_queue))
         if tool_args.get("pdf", False):
             tools.append(PdfTextExtractTool(workspace_manager=workspace_manager))
         if tool_args.get("media_generation", False) and (


### PR DESCRIPTION
## Summary
- emit start and progress messages when deep research is running
- cancel progress loop when tool completes
- forward message queue to DeepResearchTool

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c79e58d388328bafe22bc460cabea