### PR TITLE
Add websocket toggle test

### DIFF
--- a/tests/frontend/playwright.config.ts
+++ b/tests/frontend/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: __dirname,
+  use: {
+    baseURL: process.env.FRONTEND_BASE_URL || 'http://localhost:3000',
+    headless: true,
+  },
+});

--- a/tests/frontend/toggles.spec.ts
+++ b/tests/frontend/toggles.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect, WebSocketFrame } from '@playwright/test';
+
+/**
+ * Launches the app, opens the settings drawer, toggles the
+ * "Force tools on long queries" switch and verifies that the
+ * WebSocket payload reflects the change by updating the
+ * `force_tool` value.
+ */
+
+test('force_tool toggle updates server via websocket', async ({ page }) => {
+  // Capture the first WebSocket connection from the page
+  const wsPromise = page.waitForEvent('websocket');
+  await page.goto('/');
+  const ws = await wsPromise;
+
+  const frames: WebSocketFrame[] = [];
+  ws.on('framesent', frame => frames.push(frame));
+
+  // Open the settings drawer
+  await page.getByRole('button', { name: /settings/i }).click();
+
+  const toggle = page.getByLabel('Force tools on long queries');
+
+  // Disable the setting
+  await toggle.click();
+  const payloadOff = frames
+    .map(f => {
+      try {
+        return JSON.parse(f.payload.toString());
+      } catch {
+        return undefined;
+      }
+    })
+    .find(m => m && m.content && m.content.tool_args);
+
+  expect(payloadOff.content.tool_args.force_tool).toBe(false);
+  frames.length = 0;
+
+  // Enable the setting again
+  await toggle.click();
+  const payloadOn = frames
+    .map(f => {
+      try {
+        return JSON.parse(f.payload.toString());
+      } catch {
+        return undefined;
+      }
+    })
+    .find(m => m && m.content && m.content.tool_args);
+
+  expect(payloadOn.content.tool_args.force_tool).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add a minimal Playwright config under `tests/frontend`
- create `toggles.spec.ts` verifying that toggling the *Force tools on long queries* setting updates the `force_tool` value sent via WebSocket

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca92496a48328ae7cd42bdd52c2d5