### PR TITLE
Update model naming docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,13 +10,13 @@ TAVILY_API_KEY=your_tavily_key
 # OPENROUTER_API_KEY=put_your_openrouter_key_here
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 # LLM_CLIENT=openrouter-direct
-# MODEL_NAME=openrouter/meta-llama/llama-3-70b-instruct
+# MODEL_NAME=openai/gpt-4o
 
 # Optional configuration for model selection
 # LLM client to use (anthropic-direct, openai-direct, or openrouter-direct)
 LLM_CLIENT=anthropic-direct
 # Default model to use with the LLM client
-MODEL_NAME=claude-sonnet-4@20250514
+MODEL_NAME=anthropic/claude-sonnet-4@20250514
 
 
 # For better performance you can use combine between SERPAPI and FIRECRAWL to replace TAVILY

--- a/README.md
+++ b/README.md
@@ -127,16 +127,6 @@ Image Search Tool  (Optional, good for more beautiful output)
 SERPAPI_API_KEY=your_serpapi_key
 ```
 
-### OpenRouter Model Names
-
-Prefix model identifiers with `openrouter/` or `or:` so the client factory can
-detect and use `OpenRouterClient`. Example:
-
-```bash
---model-name openrouter/meta-llama/llama-3-70b-instruct
-```
-
-
 ## Installation
 
 ### Docker Installation (Recommended)
@@ -269,10 +259,10 @@ The agent loads a default set of tools based on the selected model:
 |-------|---------------|-----|-----------------|-----------------|---------|
 | anthropic/claude-sonnet-4 | false | true | true | true | true |
 | anthropic/claude-opus-4   | false | true | true | true | true |
-| openrouter/google/gemini-2.5-flash-001 | true | false | false | false | false |
-| openrouter/google/gemini-2.5-pro | true | false | false | false | false |
-| openrouter/openai/gpt-4.1-mini | true | false | false | false | false |
-| openrouter/openai/gpt-4.1-nano | true | false | false | false | false |
+| google/gemini-2.5-flash-001 | true | false | false | false | false |
+| google/gemini-2.5-pro | true | false | false | false | false |
+| openai/gpt-4.1-mini | true | false | false | false | false |
+| openai/gpt-4.1-nano | true | false | false | false | false |
 
 Unlisted tools default to `false`.
 

--- a/RUNNING_WITH_LOCAL_MODELS.md
+++ b/RUNNING_WITH_LOCAL_MODELS.md
@@ -67,13 +67,13 @@ Replace `<your-lmstudio-ip>:<port>` and `<your-model-identifier-in-lmstudio>` wi
 
 ## Using OpenRouter Models
 
-OpenRouter offers an OpenAI-compatible API for many community models. Set `OPENROUTER_API_KEY` and optionally `OPENROUTER_BASE_URL` before running. Start the agent with `--llm-client openrouter-direct` and prefix your model name with `openrouter/`.
+OpenRouter offers an OpenAI-compatible API for many community models. Set `OPENROUTER_API_KEY` and optionally `OPENROUTER_BASE_URL` before running. Start the agent with `--llm-client openrouter-direct` and specify the model using its `provider/model` slug.
 
 ### Example
 ```bash
-python cli.py 
-    --llm-client openrouter-direct 
-    --model-name openrouter/meta-llama/llama-3-70b-instruct
+python cli.py
+    --llm-client openrouter-direct
+    --model-name openai/gpt-4o
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- clean up README by removing the openrouter prefix section
- show provider/model slugs in Model Defaults
- adjust local model docs to use provider/model format
- update example env vars accordingly

## Testing
- `pytest -q`
- `pip install pre-commit` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685d849954e08328a82bcf0303c781f3